### PR TITLE
Dev environment fixes and cleanup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,12 @@
     "vscode": {
       "settings": { 
         "terminal.integrated.shell.linux": "/bin/bash"
-      }
+      },
+      "extensions": [
+        "vscjava.vscode-java-pack"
+      ]
     }
   },
-  //"mounts": [ "source=${localWorkspaceFolder},target=/work,type=bind" ],
-  "remoteUser": "root"
+  "remoteUser": "root",
+  "postStartCommand": "/usr/share/logstash/bin/logstash -f /usr/share/logstash/config/logstash.conf"
 }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To create a sample file, follow the following steps:
 1)	Copy the output plugin configuration below to your Logstash configuration file:
 ```
 output {
-    microsoft-sentinel-log-analytics-logstash-output-plugin {
+    microsoft_sentinel_output {
         create_sample_file => true
         sample_file_path => "<enter the path to the file in which the sample data will be written>" #for example: "c:\\temp" (for windows) or "/var/log" for Linux.
     }
@@ -64,7 +64,7 @@ input {
 }
 
 output {
-    microsoft-sentinel-log-analytics-logstash-output-plugin {
+    microsoft_sentinel_output {
         create_sample_file => true
         sample_file_path => "<enter the path to the file in which the sample data will be written>" #for example: "c:\\temp" (for windows) or "/var/log" for Linux.
     }
@@ -106,7 +106,7 @@ After retrieving the required values replace the output section of the Logstash 
 Here is an example for the output plugin configuration section:
 ```
 output {
-    microsoft-sentinel-log-analytics-logstash-output-plugin {
+    microsoft_sentinel_output {
         client_app_Id => "<enter your client_app_id value here>"
         client_app_secret => "<enter your client_app_secret value here>"
         tenant_id => "<enter your tenant id here>"
@@ -152,7 +152,7 @@ input {
  filter {
 }
 output {
-    microsoft-sentinel-log-analytics-logstash-output-plugin {
+    microsoft_sentinel_output {
       client_app_Id => "619c1731-15ca-4403-9c61-xxxxxxxxxxxx"
       client_app_secret => "xxxxxxxxxxxxxxxx"
       tenant_id => "72f988bf-86f1-41af-91ab-xxxxxxxxxxxx"
@@ -176,7 +176,7 @@ input {
  filter {
 }
 output {
-    microsoft-sentinel-log-analytics-logstash-output-plugin {
+    microsoft_sentinel_output {
       client_app_Id => "619c1731-15ca-4403-9c61-xxxxxxxxxxxx"
       client_app_secret => "xxxxxxxxxxxxxxxx"
       tenant_id => "72f988bf-86f1-41af-91ab-xxxxxxxxxxxx"
@@ -196,7 +196,7 @@ input {
 }
 
 output {
-    microsoft-sentinel-log-analytics-logstash-output-plugin {
+    microsoft_sentinel_output {
       client_app_Id => "${CLIENT_APP_ID}"
       client_app_secret => "${CLIENT_APP_SECRET}"
       tenant_id => "${TENANT_ID}"

--- a/README.md
+++ b/README.md
@@ -243,28 +243,31 @@ To debug the plugin, follow these steps:
 
 ### 1. Open the Project in a Dev Container. (This dev container was tested on Visual Studio Code and Intellij Idea but should work on any other IDE with support)
 
-### 2. Inside the dev container, make sure all necessary prerequisites are installed, including Logstash and the plugin. (run /usr/share/logstash/bin/logstash-plugin and verify the plugin is listed)
+### 2. Use the Debugger:
+You should be able to simple hit "Run -> Debug", the debugger will connect and you can put breakpoints in the plugin code.
 
-### 3. Run Logstash process:
-Start Logstash with the following command to make it listen on port 5005 for remote connections:
-```
-/usr/share/logstash/bin/logstash -f /usr/share/logstash/config/logstash.conf
-```
-This should run Logstash in remote debugging mode since `LS_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"` was set in the dockerfile
+#### How does this setup work?
+ the dev container is built by the Dockerfile. in this Dockerfile we defined `ENV LS_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"`. this makes every logstash process to run in debug mode and wait for a remote debugger on port 5005
 
-### 4. Use the Debugger:
-Use the launch.json configuration in the .vscode directory to run the debugger. This will connect to the Logstash process:
+then in devcontainer.json we have this - 
+`"postStartCommand": "/usr/share/logstash/bin/logstash -f /usr/share/logstash/config/logstash.conf"`
+so the Logstash process starts after the dev container is up and running and waits for a debugger
+
+and we have this launch.json:
 ```
-{
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "type": "java",
-      "name": "Debug Logstash Plugin",
-      "request": "attach",
-      "hostName": "localhost",
-      "port": 5005
-    }
-  ]
-}
+"configurations": [
+        {
+            "type": "java",
+            "name": "Remote Debug Logstash",
+            "request": "attach",
+            "hostName": "localhost",
+            "port": 5005
+        }
+    ]
 ```
+so when we start a debug session, it connects to port 5005 and attached a remote debugger
+
+#### How to debug with new changes?
+If you made changes to the plugin and you want to debug the code after changes, you will have to rebuild the dev container. This is because currently the running Logstash process is running with the plugin that was installed during the container build.
+
+To rebuild the dev container: ctrl + shift + p --> Dev Containers: Rebuild Container

--- a/envsInstallationResources/Logstash8.16/Dockerfile
+++ b/envsInstallationResources/Logstash8.16/Dockerfile
@@ -44,9 +44,9 @@ RUN ./bin/logstash-plugin install logstash-input-beats
 
 # Copy the plugin code and Gradle files into the container
 COPY ../src/main/java/org/logstashplugins /usr/share/logstash/plugins/my-plugin/src/main/java/org/logstashplugins
-COPY ../envsInstallationResources/Logstash8.16/settings.gradle /usr/share/logstash/plugins/my-plugin/settings.gradle
-COPY ../envsInstallationResources/Logstash8.16/build.gradle /usr/share/logstash/plugins/my-plugin/build.gradle
-COPY ../envsInstallationResources/Logstash8.16/rubyUtils.gradle /usr/share/rubyUtils.gradle
+COPY ../src/main/java/org/logstashplugins/settings.gradle /usr/share/logstash/plugins/my-plugin/settings.gradle
+COPY ../src/main/java/org/logstashplugins/build.gradle /usr/share/logstash/plugins/my-plugin/build.gradle
+COPY ../src/main/java/org/logstashplugins/rubyUtils.gradle /usr/share/rubyUtils.gradle
 
 # Download the versions.yml files
 RUN wget -O /usr/share/logstash/plugins/my-plugin/versions.yml https://raw.githubusercontent.com/elastic/logstash/main/versions.yml
@@ -72,7 +72,7 @@ RUN ls -l /usr/share/logstash/plugins/my-plugin/build/libs
 RUN /usr/share/logstash/bin/logstash-plugin install --no-verify --local /usr/share/logstash/plugins/my-plugin/logstash-output-microsoft_sentinel_output-0.1.0-java.gem
 
 # Copy the Logstash configuration file
-COPY ../envsInstallationResources/Logstash8.16/logstash.conf /usr/share/logstash/config/logstash.conf
+COPY ../src/main/java/org/logstashplugins/logstash.conf /usr/share/logstash/config/logstash.conf
 
 # Configure SSH
 RUN mkdir /var/run/sshd && \

--- a/envsInstallationResources/Logstash8.16/build.gradle
+++ b/envsInstallationResources/Logstash8.16/build.gradle
@@ -33,7 +33,7 @@ pluginInfo.email           = ['info@elastic.co']
 pluginInfo.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
 pluginInfo.pluginType      = "output"
 pluginInfo.pluginClass     = "MicrosoftSentinelOutput"
-pluginInfo.pluginName      = "microsoft-sentinel-log-analytics-logstash-output-plugin" // must match the @LogstashPlugin annotation in the main plugin class
+pluginInfo.pluginName      = "microsoft_sentinel_output" // must match the @LogstashPlugin annotation in the main plugin class
 // ===========================================================================
 
 java {

--- a/envsInstallationResources/Logstash8.16/logstash.conf
+++ b/envsInstallationResources/Logstash8.16/logstash.conf
@@ -3,7 +3,7 @@ input {
 }
 
 output {
-  microsoft-sentinel-log-analytics-logstash-output-plugin {
+  microsoft_sentinel_output {
     prefix => "Logstash output: "
   }
 }

--- a/envsInstallationResources/Logstash8.16/rubyUtils.gradle
+++ b/envsInstallationResources/Logstash8.16/rubyUtils.gradle
@@ -414,6 +414,10 @@ void validatePluginJar(File pluginJar, String group) {
             if (pluginAnnotation != pluginInfo.pluginName) {
                 validationErrors.add("The 'name' property on the @LogstashPlugin (which is '" + pluginAnnotation + "') must match the 'pluginName' property which is defined as '" + pluginInfo.pluginName + "' in the build.gradle file")
             }
+
+            if (pluginAnnotation.replace("_", "").toLowerCase() != pluginInfo.pluginClass.toLowerCase()) {
+                validationErrors.add("The 'name' property on the @LogstashPlugin (which is '" + pluginAnnotation + "') must match the plugin class name '" + pluginInfo.pluginClass + "' excluding casing and underscores")
+            }
         }
     }
 

--- a/src/main/java/org/logstashplugins/MicrosoftSentinelOutput.java
+++ b/src/main/java/org/logstashplugins/MicrosoftSentinelOutput.java
@@ -15,7 +15,7 @@ import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 
 // class name must match plugin name
-@LogstashPlugin(name = "microsoft-sentinel-log-analytics-logstash-output-plugin")
+@LogstashPlugin(name = "microsoft_sentinel_output")
 public class MicrosoftSentinelOutput implements Output {
 
     public static final PluginConfigSpec<String> PREFIX_CONFIG =

--- a/src/main/java/org/logstashplugins/settings.gradle
+++ b/src/main/java/org/logstashplugins/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'my-plugin'


### PR DESCRIPTION
1. create a folder envsInstallationResources to hold a folder per Logstash version. each such folder holds all the needed resources to build a container with a running Logstash in that version
2. move current installation resources for Logstash 8.16 from src folder to envsInstallationResources folder
3. add devcontainer.json change to make Logstash run once the dev container is up - this will allow immediately clicking "debug" and the debugger should connect to the running Logstash instance
4.  add devcontainer.json change to install the Extension Pack for Java in Visual Studio
5. change plugin name due to this constraint - https://github.com/elastic/logstash/blob/e094054c0e99382aa3e2c666cbd2f1046c1e1da2/rubyUtils.gradle#L419
6. update Readme.md to explain about debugging