### PR TITLE
Threads Management and Graceful Shutdown mechanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,11 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
+
+    // Logging
+    implementation 'org.slf4j:slf4j-api:1.7.30'
+    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    
 }
 
 clean {

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/LAEventsHandler.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/LAEventsHandler.java
@@ -1,5 +1,8 @@
 package org.logstashplugins.LogAnalyticsEventsHandler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -11,12 +14,15 @@ import org.logstashplugins.LogAnalyticsEventsHandler.Workers.SenderWorker;
 import org.logstashplugins.LogAnalyticsEventsHandler.Workers.Worker;
 
 public class LAEventsHandler {
+    private static final Logger logger = LoggerFactory.getLogger(LAEventsHandler.class);
+
     private LAEventsHandlerConfiguration configuration;
     private BlockingQueue<LAEventsHandlerEvent> eventsQueue;
     private BlockingQueue<List<Object>> batchesQueue;
     private ScheduledExecutorService batchersExecutorService;
     private ScheduledExecutorService sendersExecutorService;
-    private Set<Worker> workers;
+    private Set<BatcherWorker> batcherWorkers;
+    private Set<SenderWorker> senderWorkers;
 
     public LAEventsHandler(LAEventsHandlerConfiguration configuration) {
         eventsQueue = new LinkedBlockingQueue<>();
@@ -26,18 +32,19 @@ public class LAEventsHandler {
         int senderWorkerCount = getSenderWorkerCount();
         batchersExecutorService = Executors.newScheduledThreadPool(batcherWorkerCount); 
         sendersExecutorService = Executors.newScheduledThreadPool(batcherWorkerCount); 
-        workers = new HashSet<>();
+        batcherWorkers = new HashSet<>();
+        senderWorkers = new HashSet<>();
 
         // Start batcher workers and sender workers. The ScheduledExecutorService will make sure that terminated workers are restarted.
         for (int i = 0; i < batcherWorkerCount; i++) {
             BatcherWorker batcherWorker = new BatcherWorker(eventsQueue, batchesQueue, configuration);
             batchersExecutorService.scheduleAtFixedRate(batcherWorker, 0, 1, TimeUnit.MINUTES);
-            workers.add(batcherWorker);
+            batcherWorkers.add(batcherWorker);
         }
         for (int i = 0; i < senderWorkerCount; i++) {
             SenderWorker senderWorker = new SenderWorker(batchesQueue, configuration);
             sendersExecutorService.scheduleAtFixedRate(senderWorker, i, 1, TimeUnit.MINUTES);
-            workers.add(senderWorker);
+            senderWorkers.add(senderWorker);
         }
     }
 
@@ -46,23 +53,51 @@ public class LAEventsHandler {
     }
 
     public void shutdown() {
-        workers.forEach(Worker::shutdown);
-        batchersExecutorService.shutdown();
-        sendersExecutorService.shutdown();
-
+        logger.info("Shutting down Log Analytics Events Handler");
         int shutdownTimeSeconds = Optional.ofNullable(configuration.getMaxGracefulShutdownTimeSeconds())
                            .filter(time -> time != 0)
                            .orElse(60);
+        double batchersToSendersRatio = (double) batcherWorkers.size() / senderWorkers.size();
+        int batchersMaxTimeToShutdown = (int) (shutdownTimeSeconds * batchersToSendersRatio);
+
+        // call shutdown on workers to stop them gracefully. First the batchers, then the senders
+        shutdownWorkersConcurrently(batcherWorkers, batchersMaxTimeToShutdown);
+        logger.info("Batchers have been shut down");
+        shutdownWorkersConcurrently(senderWorkers, shutdownTimeSeconds - batchersMaxTimeToShutdown);
+        logger.info("Senders have been shut down");
+
+        // shutdown the executor services
+        batchersExecutorService.shutdown();
+        sendersExecutorService.shutdown();
+
         try {
             if (!batchersExecutorService.awaitTermination(shutdownTimeSeconds , TimeUnit.SECONDS)) {
+                logger.warn("Batchers executor service did not terminate in the specified time. Forcing shutdown.");
                 batchersExecutorService.shutdownNow();
             }
             if (!sendersExecutorService.awaitTermination(shutdownTimeSeconds , TimeUnit.SECONDS)) {
+                logger.warn("Senders executor service did not terminate in the specified time. Forcing shutdown.");
                 sendersExecutorService.shutdownNow();
             }
         } catch (InterruptedException e) {
+            logger.warn("Interrupted while waiting for executor services to terminate. Forcing shutdown.");
             batchersExecutorService.shutdownNow();
             sendersExecutorService.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        logger.info("Log Analytics Events Handler has been shut down");
+    }
+
+    private void shutdownWorkersConcurrently(Set<? extends Worker> workers, int maxGracefulShutdownTimeSeconds) {
+        ExecutorService shutdownExecutor = Executors.newFixedThreadPool(workers.size());
+        for (Worker worker : workers) {
+            shutdownExecutor.submit(worker::shutdown);
+        }
+        shutdownExecutor.shutdown();
+        try {
+            shutdownExecutor.awaitTermination(maxGracefulShutdownTimeSeconds, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            shutdownExecutor.shutdownNow();
             Thread.currentThread().interrupt();
         }
     }

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/LAEventsHandler.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/LAEventsHandler.java
@@ -1,29 +1,79 @@
 package org.logstashplugins.LogAnalyticsEventsHandler;
 
+import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.*;
 
 import org.logstashplugins.LogAnalyticsEventsHandler.Workers.BatcherWorker;
 import org.logstashplugins.LogAnalyticsEventsHandler.Workers.SenderWorker;
+import org.logstashplugins.LogAnalyticsEventsHandler.Workers.Worker;
 
 public class LAEventsHandler {
     private LAEventsHandlerConfiguration configuration;
     private BlockingQueue<LAEventsHandlerEvent> eventsQueue;
     private BlockingQueue<List<Object>> batchesQueue;
+    private ScheduledExecutorService batchersExecutorService;
+    private ScheduledExecutorService sendersExecutorService;
+    private Set<Worker> workers;
 
     public LAEventsHandler(LAEventsHandlerConfiguration configuration) {
-        eventsQueue = new LinkedBlockingQueue<LAEventsHandlerEvent>();
-        batchesQueue = new LinkedBlockingQueue<List<Object>>();
+        eventsQueue = new LinkedBlockingQueue<>();
+        batchesQueue = new LinkedBlockingQueue<>();
         this.configuration = configuration;
+        int batcherWorkerCount = getBatcherWorkerCount();
+        int senderWorkerCount = getSenderWorkerCount();
+        batchersExecutorService = Executors.newScheduledThreadPool(batcherWorkerCount); 
+        sendersExecutorService = Executors.newScheduledThreadPool(batcherWorkerCount); 
+        workers = new HashSet<>();
 
-        for (int i = 0; i < 3; i++) {
-            new Thread(new BatcherWorker(eventsQueue, batchesQueue, configuration)).start();
-            new Thread(new SenderWorker(batchesQueue, i, configuration)).start();
+        // Start batcher workers and sender workers. The ScheduledExecutorService will make sure that terminated workers are restarted.
+        for (int i = 0; i < batcherWorkerCount; i++) {
+            BatcherWorker batcherWorker = new BatcherWorker(eventsQueue, batchesQueue, configuration);
+            batchersExecutorService.scheduleAtFixedRate(batcherWorker, 0, 1, TimeUnit.MINUTES);
+            workers.add(batcherWorker);
+        }
+        for (int i = 0; i < senderWorkerCount; i++) {
+            SenderWorker senderWorker = new SenderWorker(batchesQueue, configuration);
+            batchersExecutorService.scheduleAtFixedRate(senderWorker, i, 1, TimeUnit.MINUTES);
+            workers.add(senderWorker);
         }
     }
 
     public void handle(LAEventsHandlerEvent event) {
         eventsQueue.add(event);
+    }
+
+    public void shutdown() {
+        workers.forEach(Worker::shutdown);
+        batchersExecutorService.shutdown();
+        sendersExecutorService.shutdown();
+
+        int shutdownTimeSeconds = Optional.ofNullable(configuration.getMaxGracefulShutdownTimeSeconds())
+                           .filter(time -> time != 0)
+                           .orElse(60);
+        try {
+            if (!batchersExecutorService.awaitTermination(shutdownTimeSeconds , TimeUnit.SECONDS)) {
+                batchersExecutorService.shutdownNow();
+            }
+            if (!sendersExecutorService.awaitTermination(shutdownTimeSeconds , TimeUnit.SECONDS)) {
+                sendersExecutorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            batchersExecutorService.shutdownNow();
+            sendersExecutorService.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private int getBatcherWorkerCount() {
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        return (availableProcessors - 1) / 2;
+    }
+
+    private int getSenderWorkerCount() {
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        return (availableProcessors - 1) / 2;
     }
 }

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/LAEventsHandler.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/LAEventsHandler.java
@@ -36,7 +36,7 @@ public class LAEventsHandler {
         }
         for (int i = 0; i < senderWorkerCount; i++) {
             SenderWorker senderWorker = new SenderWorker(batchesQueue, configuration);
-            batchersExecutorService.scheduleAtFixedRate(senderWorker, i, 1, TimeUnit.MINUTES);
+            sendersExecutorService.scheduleAtFixedRate(senderWorker, i, 1, TimeUnit.MINUTES);
             workers.add(senderWorker);
         }
     }

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/LAEventsHandlerConfiguration.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/LAEventsHandlerConfiguration.java
@@ -16,4 +16,7 @@ public class LAEventsHandlerConfiguration {
     private String clientId;
     private String clientSecret;
     private String tenantId;
+
+    // Shutdown configuration
+    private int maxGracefulShutdownTimeSeconds;
 }

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/AbstractWorker.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/AbstractWorker.java
@@ -3,11 +3,12 @@ package org.logstashplugins.LogAnalyticsEventsHandler.Workers;
 public abstract class AbstractWorker<T> implements Worker {
     @Override
     public void run() {
-        while (true) {
+        while (isRunning()) {
             try {
                 process();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                shutdown();
                 break;
             }
         }

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/AbstractWorker.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/AbstractWorker.java
@@ -1,6 +1,8 @@
 package org.logstashplugins.LogAnalyticsEventsHandler.Workers;
 
 public abstract class AbstractWorker<T> implements Worker {
+    protected volatile boolean running;
+
     @Override
     public void run() {
         while (isRunning()) {

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/BatcherWorker.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/BatcherWorker.java
@@ -7,8 +7,12 @@ import java.util.concurrent.BlockingQueue;
 import org.logstashplugins.LogstashLAHandlerEvent;
 import org.logstashplugins.LogAnalyticsEventsHandler.LAEventsHandlerConfiguration;
 import org.logstashplugins.LogAnalyticsEventsHandler.LAEventsHandlerEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BatcherWorker extends AbstractWorker<LogstashLAHandlerEvent> {
+    private static final Logger logger = LoggerFactory.getLogger(BatcherWorker.class);
+    
     private BlockingQueue<LAEventsHandlerEvent> eventsQueue;
     private BlockingQueue<List<Object>> batchesQueue;
     private LAEventsHandlerConfiguration configuration;
@@ -40,14 +44,18 @@ public class BatcherWorker extends AbstractWorker<LogstashLAHandlerEvent> {
 
     @Override
     public void shutdown() {
+        logger.info("Shutting down BatcherWorker. Thread id: " + Thread.currentThread().getId());
+
         running = false;
 
         // Create one last batch with remaining events in the queue
         List<Object> batch = new ArrayList<Object>();
         eventsQueue.drainTo(batch);
         if (!batch.isEmpty()) {
+            logger.info("Adding last batch to queue. Batch size: " + batch.size());
             batchesQueue.add(batch);
         }
+        logger.info("BatcherWorker shutdown complete. Thread id: " + Thread.currentThread().getId());
     }
 
     @Override

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/BatcherWorker.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/BatcherWorker.java
@@ -3,7 +3,6 @@ package org.logstashplugins.LogAnalyticsEventsHandler.Workers;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 import org.logstashplugins.LogstashLAHandlerEvent;
 import org.logstashplugins.LogAnalyticsEventsHandler.LAEventsHandlerConfiguration;
@@ -13,6 +12,7 @@ public class BatcherWorker extends AbstractWorker<LogstashLAHandlerEvent> {
     private BlockingQueue<LAEventsHandlerEvent> eventsQueue;
     private BlockingQueue<List<Object>> batchesQueue;
     private LAEventsHandlerConfiguration configuration;
+    private boolean running;
     
     public BatcherWorker(BlockingQueue<LAEventsHandlerEvent> eventsQueue, 
                         BlockingQueue<List<Object>> batchesQueue, 
@@ -20,6 +20,7 @@ public class BatcherWorker extends AbstractWorker<LogstashLAHandlerEvent> {
         this.eventsQueue = eventsQueue; 
         this.batchesQueue = batchesQueue;
         this.configuration = configuration;
+        this.running = true;
     }
 
     @Override
@@ -27,15 +28,30 @@ public class BatcherWorker extends AbstractWorker<LogstashLAHandlerEvent> {
         long startTimeMillis = System.currentTimeMillis();
         List<Object> batch = new ArrayList<Object>();
         
-        while (System.currentTimeMillis() - startTimeMillis < configuration.getMaxWaitingTimeSeconds() * 1000) {
-            LAEventsHandlerEvent event = eventsQueue.poll(5, TimeUnit.SECONDS);
-            if (event != null) {
-                batch.add(event.getLog());
-            }
+        while (running && !Thread.currentThread().isInterrupted() && 
+                System.currentTimeMillis() - startTimeMillis < configuration.getMaxWaitingTimeSeconds() * 1000) {
+            eventsQueue.drainTo(batch);
         }
 
         if (!batch.isEmpty()) {
             batchesQueue.add(batch);
         }
+    }
+
+    @Override
+    public void shutdown() {
+        running = false;
+
+        // Create one last batch with remaining events in the queue
+        List<Object> batch = new ArrayList<Object>();
+        eventsQueue.drainTo(batch);
+        if (!batch.isEmpty()) {
+            batchesQueue.add(batch);
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
     }
 }

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/BatcherWorker.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/BatcherWorker.java
@@ -16,7 +16,6 @@ public class BatcherWorker extends AbstractWorker<LogstashLAHandlerEvent> {
     private BlockingQueue<LAEventsHandlerEvent> eventsQueue;
     private BlockingQueue<List<Object>> batchesQueue;
     private LAEventsHandlerConfiguration configuration;
-    private boolean running;
     
     public BatcherWorker(BlockingQueue<LAEventsHandlerEvent> eventsQueue, 
                         BlockingQueue<List<Object>> batchesQueue, 

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/SenderWorker.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/SenderWorker.java
@@ -19,7 +19,6 @@ public class SenderWorker extends AbstractWorker<List<Object>> {
     private BlockingQueue<List<Object>> batchesQueue;
     private LogsIngestionClient client;
     private LAEventsHandlerConfiguration configuration;
-    private boolean running;
     
     public SenderWorker(BlockingQueue<List<Object>> batchesQueue, 
                         LAEventsHandlerConfiguration configuration) {

--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/Worker.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/Worker.java
@@ -2,4 +2,6 @@ package org.logstashplugins.LogAnalyticsEventsHandler.Workers;
 
 public interface Worker extends Runnable {
     void process() throws InterruptedException;
+    void shutdown();
+    boolean isRunning();
 }

--- a/src/main/java/org/logstashplugins/MicrosoftSentinelOutput.java
+++ b/src/main/java/org/logstashplugins/MicrosoftSentinelOutput.java
@@ -99,6 +99,7 @@ public class MicrosoftSentinelOutput implements Output {
     @Override
     public void stop() {
         stopped = true;
+        eventsHandler.shutdown();
         done.countDown();
     }
 

--- a/src/main/java/org/logstashplugins/MicrosoftSentinelOutput.java
+++ b/src/main/java/org/logstashplugins/MicrosoftSentinelOutput.java
@@ -18,11 +18,15 @@ import java.util.concurrent.CountDownLatch;
 import org.logstashplugins.LogAnalyticsEventsHandler.LAEventsHandler;
 import org.logstashplugins.LogAnalyticsEventsHandler.LAEventsHandlerConfiguration;
 import org.logstashplugins.LogAnalyticsEventsHandler.LAEventsHandlerEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // class name must match plugin name
 @LogstashPlugin(name = "microsoft_sentinel_output")
 public class MicrosoftSentinelOutput implements Output {
 
+    private static final Logger logger = LoggerFactory.getLogger(MicrosoftSentinelOutput.class);
+    
     public static final PluginConfigSpec<String> PREFIX_CONFIG =
             PluginConfigSpec.stringSetting("prefix", "");
 
@@ -66,6 +70,7 @@ public class MicrosoftSentinelOutput implements Output {
         // constructors should validate configuration options
         this.id = id;
 
+        logger.info("Starting Microsoft Sentinel output plugin");
         LAEventsHandlerConfiguration eventsHandlerConfiguration = createEventsHandlerConfiguration(config);
         keysToKeep = (List<String>) (List<?>) config.get(KEYS_TO_KEEP_CONFIG);
 
@@ -98,9 +103,11 @@ public class MicrosoftSentinelOutput implements Output {
 
     @Override
     public void stop() {
+        logger.info("Stopping Microsoft Sentinel output plugin");
         stopped = true;
         eventsHandler.shutdown();
         done.countDown();
+        logger.info("Microsoft Sentinel output plugin stopped");
     }
 
     @Override

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Console Appender -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Rolling File Appender -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/application.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- Rotate log file daily -->
+            <fileNamePattern>logs/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- Keep 30 days' worth of log files -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Root Logger -->
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>


### PR DESCRIPTION
1. Start workers using a ScheduledExecutorService to ensure that terminated workers are restarted

2. Implement a graceful shutdown process:

- Cease processing new events on the plugin level
- Flush remaining events in the queues and send remaining batches
- Shutdown batcher workers and only then sender workers
- Allow a configurable time for full graceful shutdown but force shutdown if that time is exceeded

3. Configure a logger and add shutdown logs