### PR TITLE
Fix Shutdown Mechanism in Worker Threads

### DIFF
--- a/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/AbstractWorker.java
+++ b/src/main/java/org/logstashplugins/LogAnalyticsEventsHandler/Workers/AbstractWorker.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class AbstractWorker<T> implements Worker {
     private static final Logger logger = LoggerFactory.getLogger(AbstractWorker.class);
-    protected volatile boolean running;
+    protected static volatile boolean running = true;
 
     @Override
     public void run() {

--- a/src/test/java/org/logstashplugins/unit/BatcherWorkerTest.java
+++ b/src/test/java/org/logstashplugins/unit/BatcherWorkerTest.java
@@ -7,6 +7,8 @@ import org.logstashplugins.LogAnalyticsEventsHandler.LAEventsHandlerConfiguratio
 import org.logstashplugins.LogAnalyticsEventsHandler.LAEventsHandlerEvent;
 import org.logstashplugins.LogAnalyticsEventsHandler.Workers.BatcherWorker;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -17,6 +19,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class BatcherWorkerTest {
+    private static final Logger logger = LoggerFactory.getLogger(BatcherWorkerTest.class);
 
     private BlockingQueue<LAEventsHandlerEvent> inputQueue;
     private BlockingQueue<List<Object>> sendersQueue;
@@ -29,6 +32,7 @@ public class BatcherWorkerTest {
     public void setUp() {
         configuration = new LAEventsHandlerConfiguration.BatcherWorkerConfig();
         configuration.setMaxWaitingTimeSecondsForBatch(10);
+        configuration.setSleepTimeMillis(100);  // Set shorter sleep time for testing
         inputQueue = new LinkedBlockingQueue<>();
         sendersQueue = new LinkedBlockingQueue<>();
         unifiersQueue = new LinkedBlockingQueue<>();
@@ -79,20 +83,63 @@ public class BatcherWorkerTest {
     }
 
     @Test
-    public void testShutdown() {
-        LAEventsHandlerEvent event1 = mock(LAEventsHandlerEvent.class);
-        inputQueue.add(event1);
+    public void testShutdown() throws InterruptedException {
+        logger.error("TEST START: Starting shutdown test with multiple workers...");
+        
+        // Create multiple workers sharing the same queues
+        BatcherWorker worker1 = new BatcherWorker(inputQueue, sendersQueue, unifiersQueue, configuration);
+        BatcherWorker worker2 = new BatcherWorker(inputQueue, sendersQueue, unifiersQueue, configuration);
+        
+        logger.error("Created workers");
 
-        assertTrue(batcherWorker.isRunning());
+        // Add test events that should be processed
+        for (int i = 0; i < 5; i++) {
+            inputQueue.add(mock(LAEventsHandlerEvent.class));
+        }
+        logger.error("Added 5 initial events");
 
-        batcherWorker.shutdown();
+        // Process events with both workers
+        worker1.process();
+        worker2.process();
 
-        assertEquals(0, inputQueue.size());
-        assertEquals(1, sendersQueue.size());
-        List<Object> batch = sendersQueue.poll();
-        assertNotNull(batch);
-        assertEquals(1, batch.size());
-        assertTrue(batch.contains(event1));
-        assertFalse(batcherWorker.isRunning());
+        // Verify initial processing works
+        assertTrue(inputQueue.isEmpty(), "Initial events should be processed");
+        assertTrue(sendersQueue.size() > 0 || unifiersQueue.size() > 0, "Events should be processed");
+        int processedEvents = sendersQueue.size() + unifiersQueue.size();
+        logger.error("Initial events were processed: " + processedEvents + " batches created");
+
+        // Clear output queues for next phase
+        sendersQueue.clear();
+        unifiersQueue.clear();
+
+        // Shutdown worker1
+        logger.error("Shutting down worker1...");
+        worker1.shutdown();
+
+        // Add post-shutdown events
+        for (int i = 0; i < 5; i++) {
+            inputQueue.add(mock(LAEventsHandlerEvent.class));
+        }
+        logger.error("Added 5 post-shutdown events");
+
+        // Try to process with both workers
+        worker1.process();  // Should not process (shutdown)
+        worker2.process();  // Should not process (shared shutdown state)
+
+        // Verify post-shutdown state
+        assertEquals(5, inputQueue.size(), "Post-shutdown events should remain in input queue");
+        assertEquals(0, sendersQueue.size() + unifiersQueue.size(), "No events should be processed after shutdown");
+        assertFalse(worker1.isRunning(), "Worker1 should be stopped");
+        assertFalse(worker2.isRunning(), "Worker2 should be stopped due to shared state");
+
+        // Log final state for debugging
+        logger.error("After shutdown state:");
+        logger.error("- Events in input queue: " + inputQueue.size());
+        logger.error("- Events processed after shutdown: " + (sendersQueue.size() + unifiersQueue.size()));
+        logger.error("- Worker1 running: " + worker1.isRunning());
+        logger.error("- Worker2 running: " + worker2.isRunning());
+
+        // Clean up
+        worker2.shutdown();
     }
 }


### PR DESCRIPTION
Made worker 'running' flag static to ensure consistent shutdown state across all instances in order to prevents worker threads from continuing to process after shutdown is initiated.

Edited the testShutdown test case to verify workers are shutting down as expected and not taking events from the queue post shutdown command. The test succeeded with the change and failed without it.

Ran a local shutdown test which resulted in:
- All workers properly shutting down when requested
- No worker restarted after shutdown